### PR TITLE
[WIP] Multi input records / scatter / subworkflow implementation

### DIFF
--- a/Workflows/fastqSE2bam.multisamples.cwl
+++ b/Workflows/fastqSE2bam.multisamples.cwl
@@ -45,6 +45,7 @@ steps:
     in:
       reference: reference
       nthreads: nthreads
+      inputSamples: inputSamples
       RG_ID:
         valueFrom: $(inputs.inputSamples.RG_ID)
       RG_PL:
@@ -60,13 +61,7 @@ steps:
       outprefix:
         valueFrom: $(inputs.inputSamples.outprefix)
     scatter:
-      - RG_ID
-      - RG_PL
-      - RG_PU
-      - RG_LB
-      - RG_SM
-      - fq
-      - outprefix
+      - inputSamples
     scatterMethod: dotproduct
     out:
       - sam

--- a/Workflows/fastqSE2bam.multisamples.cwl
+++ b/Workflows/fastqSE2bam.multisamples.cwl
@@ -1,0 +1,73 @@
+cwlVersion: v1.0
+class: Workflow
+requirements:
+  - SubworkflowFeatureRequirement: {}
+  - StepInputExpressionRequirement: {}
+
+inputs:
+  reference:
+    type: File
+    format: edam:format_1929
+    doc: FastA file for reference genome
+    secondaryFiles:
+      - .amb
+      - .ann
+      - .bwt
+      - .pac
+      - .sa
+  nthreads:
+    type: int
+  inputSamples:
+    type:
+      type: record[]
+      name: samples
+      fields:
+        - name: RG_ID
+          type: string
+        - name: RG_PL
+          type: string
+        - name: RG_PU
+          type: string
+        - name: RG_LB
+          type: string
+        - name: RG_SM
+          type: string
+        - name: fq
+          type: File
+        - name: outprefix
+          type: string
+
+steps:
+  fastqSE2bam:
+    run: fastqSE2bam.cwl
+    in:
+      reference: reference
+      nthreads: nthreads
+      RG_ID:
+        valueFrom: inputSamples.RG_ID
+      RG_PL:
+        valueFrom: inputSamples.RG_PL
+      RG_PU:
+        valueFrom: inputSamples.RG_PU
+      RG_LB:
+        valueFrom: inputSamples.RG_LB
+      RG_SM:
+        valueFrom: inputSamples.RG_SM
+      fq:
+        valueFrom: inputSamples.fq
+      outprefix:
+        valueFrom: inputSamples.outprefix
+    scatter:
+      - RG_ID
+      - RG_PL
+      - RG_PU
+      - RG_LB
+      - RG_SM
+      - fq
+      - outprefix
+    scatterMethod: dotproduct
+    out:
+      - sam
+      - sam_log
+      - bam
+      - bam_log

--- a/Workflows/fastqSE2bam.multisamples.cwl
+++ b/Workflows/fastqSE2bam.multisamples.cwl
@@ -1,8 +1,9 @@
 cwlVersion: v1.0
 class: Workflow
 requirements:
-  - SubworkflowFeatureRequirement: {}
-  - StepInputExpressionRequirement: {}
+  SubworkflowFeatureRequirement: {}
+  ScatterFeatureRequirement: {}
+  StepInputExpressionRequirement: {}
 
 inputs:
   reference:
@@ -19,23 +20,24 @@ inputs:
     type: int
   inputSamples:
     type:
-      type: record[]
-      name: samples
-      fields:
-        - name: RG_ID
-          type: string
-        - name: RG_PL
-          type: string
-        - name: RG_PU
-          type: string
-        - name: RG_LB
-          type: string
-        - name: RG_SM
-          type: string
-        - name: fq
-          type: File
-        - name: outprefix
-          type: string
+      type: array
+      items:
+        - type: record
+          fields:
+            RG_ID:
+              type: string
+            RG_PL:
+              type: string
+            RG_PU:
+              type: string
+            RG_LB:
+              type: string
+            RG_SM:
+              type: string
+            fq:
+              type: File
+            outprefix:
+              type: string
 
 steps:
   fastqSE2bam:
@@ -44,19 +46,19 @@ steps:
       reference: reference
       nthreads: nthreads
       RG_ID:
-        valueFrom: inputSamples.RG_ID
+        valueFrom: $(inputs.inputSamples.RG_ID)
       RG_PL:
-        valueFrom: inputSamples.RG_PL
+        valueFrom: $(inputs.inputSamples.RG_PL)
       RG_PU:
-        valueFrom: inputSamples.RG_PU
+        valueFrom: $(inputs.inputSamples.RG_PU)
       RG_LB:
-        valueFrom: inputSamples.RG_LB
+        valueFrom: $(inputs.inputSamples.RG_LB)
       RG_SM:
-        valueFrom: inputSamples.RG_SM
+        valueFrom: $(inputs.inputSamples.RG_SM)
       fq:
-        valueFrom: inputSamples.fq
+        valueFrom: $(inputs.inputSamples.fq)
       outprefix:
-        valueFrom: inputSamples.outprefix
+        valueFrom: $(inputs.inputSamples.outprefix)
     scatter:
       - RG_ID
       - RG_PL
@@ -71,3 +73,17 @@ steps:
       - sam_log
       - bam
       - bam_log
+
+outputs:
+  sam:
+    type: File[]
+    outputSource: fastqSE2bam/sam
+  sam_log:
+    type: File[]
+    outputSource: fastqSE2bam/sam_log
+  bam:
+    type: File[]
+    outputSource: fastqSE2bam/bam
+  bam_log:
+    type: File[]
+    outputSource: fastqSE2bam/bam_log

--- a/examples/multisamples/fastqSE2bam.multisamples.yaml
+++ b/examples/multisamples/fastqSE2bam.multisamples.yaml
@@ -1,21 +1,23 @@
-reference: /path/to/reference.fasta
+reference:
+  class: File
+  path: reference.fasta
 nthreads: 2
 inputSamples:
-  - RG_ID: string
-    RG_PL: string
-    RG_PU: string
-    RG_LB: string
-    RG_SM: string
+  - RG_ID: RG_ID_1
+    RG_PL: RG_PL_1
+    RG_PU: RG_PU_1
+    RG_LB: RG_LB_1
+    RG_SM: RG_SM_1
     fq:
       class: File
-      path: /path/to/data1.fastq
+      path: data1.fastq
     outprefix: data1
-  - RG_ID: string
-    RG_PL: string
-    RG_PU: string
-    RG_LB: string
-    RG_SM: string
+  - RG_ID: RG_ID_2
+    RG_PL: RG_PL_2
+    RG_PU: RG_PU_2
+    RG_LB: RG_LB_2
+    RG_SM: RG_SM_2
     fq:
       class: File
-      path: /path/to/data2.fastq
+      path: data2.fastq
     outprefix: data2

--- a/examples/multisamples/fastqSE2bam.multisamples.yaml
+++ b/examples/multisamples/fastqSE2bam.multisamples.yaml
@@ -1,0 +1,21 @@
+reference: /path/to/reference.fasta
+nthreads: 2
+inputSamples:
+  - RG_ID: string
+    RG_PL: string
+    RG_PU: string
+    RG_LB: string
+    RG_SM: string
+    fq:
+      class: File
+      path: /path/to/data1.fastq
+    outprefix: data1
+  - RG_ID: string
+    RG_PL: string
+    RG_PU: string
+    RG_LB: string
+    RG_SM: string
+    fq:
+      class: File
+      path: /path/to/data2.fastq
+    outprefix: data2


### PR DESCRIPTION
多サンプル入力の仮実装です。CWL的にどう書くか、yamlでどう与えるかを示しています。

方針:
- Subworkflow を使って single sample の workflow を多サンプル対応する
- 1つのサンプルに対応する複数の入力パラメータは record タイプとして、yaml オブジェクトの配列として渡す
- scatter で多サンプルを分散実行できるようにする

やったこと:
- CWL文法のvalidationは済み。
- 実行した際にcwltoolが意図した挙動を見せることは確認
  - 空ファイルを入力してテストした

ToDo:
- 実際のデータでテストする
- output が捕まえられるか確認する
- CWL定義ファイルが増えてきたのでディレクトリを整理する

参考:
- scatterの実装例: https://github.com/mr-c/MEGADOCK/blob/cwl/cwl/megadock.cwl by @mr-c
- record type: https://www.commonwl.org/user_guide/11-records/
